### PR TITLE
cmake: Fix KOBJ_TYPES_H_TARGET renaming

### DIFF
--- a/tests/unit/unittest.cmake
+++ b/tests/unit/unittest.cmake
@@ -20,6 +20,7 @@ endif()
 
 add_executable(testbinary ${SOURCES})
 
+set(KOBJ_TYPES_H_TARGET kobj_types_h_target)
 include($ENV{ZEPHYR_BASE}/cmake/kobj.cmake)
 add_dependencies(testbinary ${KOBJ_TYPES_H_TARGET})
 gen_kobj(KOBJ_GEN_DIR)


### PR DESCRIPTION
Fix KOBJ_TYPES_H_TARGET renaming. This commit must be 'fixup'd with
the commit that introduces the variable name.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>