### PR TITLE
cmake: Use image name prefix for non-app images only.

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -35,21 +35,15 @@ if(NOT (${CMAKE_VERSION} VERSION_LESS "3.13.0"))
   cmake_policy(SET CMP0079 OLD)
 endif()
 
-get_property(MULTI_IMAGE GLOBAL PROPERTY MULTI_IMAGE)
 get_property(IMAGE GLOBAL PROPERTY IMAGE)
 
-if(MULTI_IMAGE)
+if(IMAGE)
   set(FIRST_BOILERPLATE_EXECUTION 0)
 else()
   set(FIRST_BOILERPLATE_EXECUTION 1)
 endif()
 
-
-if(FIRST_BOILERPLATE_EXECUTION)
-  set(IMAGE 0_)
-  set(IMAGE_ALIAS)
-else()
-  set(IMAGE_ALIAS ${IMAGE})
+if (NOT FIRST_BOILERPLATE_EXECUTION)
   # Clear the Kconfig namespace of the other image.
   # Since the CMake context of each subsequent image is loaded by "add_subdirectory"
   # the Kconfig namespace is automatically restored by CMake.
@@ -61,7 +55,7 @@ else()
       unset(${name})
     endif()
   endforeach()
-endif(FIRST_BOILERPLATE_EXECUTION)
+endif()
 
 define_property(GLOBAL PROPERTY ${IMAGE}ZEPHYR_LIBS
     BRIEF_DOCS "Image-global list of all Zephyr CMake libs that should be linked in"

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -104,16 +104,8 @@ function(zephyr_cc_option)
   endforeach()
 endfunction()
 
-function(zephyr_add_multi_image)
-  get_property(MULTI_IMAGE GLOBAL PROPERTY MULTI_IMAGE)
-  if(NOT MULTI_IMAGE)
-    set_property(GLOBAL PROPERTY MULTI_IMAGE 1)
-  else()
-    MATH(EXPR incremented_multi_image "${MULTI_IMAGE}+1")
-    set_property(GLOBAL PROPERTY MULTI_IMAGE ${incremented_multi_image})
-  endif()
-  get_property(MULTI_IMAGE GLOBAL PROPERTY MULTI_IMAGE)
-  set_property(GLOBAL PROPERTY IMAGE ${MULTI_IMAGE}_)
+function(zephyr_add_multi_image image_name)
+  set_property(GLOBAL PROPERTY IMAGE ${image_name}_)
 endfunction()
 
 

--- a/samples/hello_world/CMakeLists.txt
+++ b/samples/hello_world/CMakeLists.txt
@@ -3,4 +3,4 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(hello_world)
 
-target_sources(${IMAGE}app PRIVATE src/main.c)
+target_sources(app PRIVATE src/main.c)

--- a/subsys/boot/mcuboot/CMakeLists.txt
+++ b/subsys/boot/mcuboot/CMakeLists.txt
@@ -4,7 +4,7 @@
 set(MCUBOOT_BASE "${ZEPHYR_BASE}/../mcuboot")
 assert_exists(MCUBOOT_BASE)
 
-zephyr_add_multi_image()
+zephyr_add_multi_image(mcuboot)
 add_subdirectory("${MCUBOOT_BASE}/boot/zephyr" ${CMAKE_CURRENT_BINARY_DIR}/mcuboot)
 
 # TODO: Assert that the bootloader and image use the same key.


### PR DESCRIPTION
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>