### PR TITLE
cmake: rename add_multi_image to add_executable

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -109,15 +109,15 @@ endfunction()
 # different configuration.  Examples of use include bootloaders, and
 # secure/non-secure partitions in a TrustZone environment.
 #
-# This function creates a new “app” context, equivalent to the one defined by
-# the ‘origin’ context.  The CMakeLists.txt file pointed to by the users
+# This function creates a new 'app' context, equivalent to the one defined by
+# the 'origin' context.  The CMakeLists.txt file pointed to by the users
 # 'cmake' command defines the 'origin' context.  All targets defined by the new
-# context is prefixed with the name provided in the `image_name` argument.  As
-# a result of this, in order to execute the `menuconfig` target to perform
-# configuration `image_name_menuconfig` must be used instead.  Note the targets
-# defined by the ‘origin’ context is not prefixed in any way.
+# context is prefixed with the name provided in the 'name' argument.  As
+# a result of this, in order to execute the 'menuconfig' target to perform
+# configuration 'name_menuconfig' must be used instead.  Note the targets
+# defined by the 'origin' context is not prefixed in any way.
 #
-# Only a small set of configurations is shared between the ‘origin’ context and
+# Only a small set of configurations is shared between the 'origin' context and
 # the new context, notably CMake properties.  The new context defines its own
 # set of: - CMake variables (note: not properties) - DTS configuration -
 # KConfig configuration
@@ -126,8 +126,8 @@ endfunction()
 # merges the resulting hex files. The 'flash' target is updated to use this
 # merged hex file instead of the 'zephyr.hex' file from the origin context.
 #
-function(zephyr_add_multi_image image_name)
-  set_property(GLOBAL PROPERTY IMAGE ${image_name}_)
+function(zephyr_add_executable name)
+  set_property(GLOBAL PROPERTY IMAGE ${name}_)
 endfunction()
 
 

--- a/subsys/boot/mcuboot/CMakeLists.txt
+++ b/subsys/boot/mcuboot/CMakeLists.txt
@@ -4,7 +4,7 @@
 set(MCUBOOT_BASE "${ZEPHYR_BASE}/../mcuboot")
 assert_exists(MCUBOOT_BASE)
 
-zephyr_add_multi_image(mcuboot)
+zephyr_add_executable(mcuboot)
 add_subdirectory("${MCUBOOT_BASE}/boot/zephyr" ${CMAKE_CURRENT_BINARY_DIR}/mcuboot)
 
 # TODO: Assert that the bootloader and image use the same key.


### PR DESCRIPTION
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>